### PR TITLE
Invisible Typing Indicator

### DIFF
--- a/ChatButtonsBegone.plugin.js
+++ b/ChatButtonsBegone.plugin.js
@@ -417,7 +417,7 @@ module.exports = class ChatButtonsBegone {
         if (this.settings.toolbar.inboxButton) this.styler.add(this.getCssRule(this.inboxButtonSelector));
 
         // Compatibility
-        if (this.settings.compatibility.invisibleTypingButton) this.styler.add(this.getTextAreaCssRule('.invisible-typing-button'));
+        if (this.settings.compatibility.invisibleTypingButton) this.styler.add(this.getTextAreaCssRule('.invisibleTypingButton'));
     }
 
     refreshStyles() {


### PR DESCRIPTION
Fix the toggle option to show/hide the InvisibleTypingIndicator plugin.

Reported as Issue #8 