### PR TITLE
v2.15.7 Added option to remove activity panel

### DIFF
--- a/ChatButtonsBegone.plugin.js
+++ b/ChatButtonsBegone.plugin.js
@@ -4,7 +4,7 @@
  * @description Remove annoying stuff from your Discord clients.
  * @author LancersBucket
  * @authorId 355477882082033664
- * @version 2.15.6
+ * @version 2.15.7
  * @source https://github.com/LancersBucket/plugin-RemoveChatButtons
  */
 /*@cc_on
@@ -141,7 +141,7 @@ class EventHijacker {
 const config = {
     info: {
         name: 'ChatButtonsBegone',
-        version: '2.15.6',
+        version: '2.15.7',
         github: 'https://github.com/LancersBucket/plugin-RemoveChatButtons',
         github_raw: 'https://raw.githubusercontent.com/LancersBucket/plugin-RemoveChatButtons/refs/heads/main/ChatButtonsBegone.plugin.js',
     },
@@ -466,6 +466,13 @@ const config = {
                     id: 'krispButton',
                     name: 'Remove Noise Suppression (Krisp) Button',
                     note: 'Removes the noise supression button from the user voice chat panel.',
+                    value: false,
+                },
+                {
+                    type: 'switch',
+                    id: 'activityPanel',
+                    name: 'Remove Activity Panel',
+                    note: 'Removes the activity panel from the user voice chat panel.',
                     value: false,
                 },
             ],
@@ -914,6 +921,7 @@ module.exports = class ChatButtonsBegone {
         // Why in the nine hells is the soundboard button in it's own special div? Did Discord do this just to piss me in particular off?
         if (this.settings.voice.soundboardPanelButton) this.addCssStyle('div[class^="actionButtons"] div:has(> button[aria-label="Open Soundboard"])');
         if (this.settings.voice.krispButton) this.addCssStyle('button[aria-label="Noise Suppression powered by Krisp"]');
+        if (this.settings.voice.activityPanel) this.addCssStyle('div[class*="activityPanel"]');
 
         /// Title Bar ///
         if (this.settings.toolbar.navButtons) this.addCssStyle('[class^="backForwardButtons"]');

--- a/ChatButtonsBegone.plugin.js
+++ b/ChatButtonsBegone.plugin.js
@@ -468,13 +468,6 @@ const config = {
                     note: 'Removes the noise supression button from the user voice chat panel.',
                     value: false,
                 },
-                {
-                    type: 'switch',
-                    id: 'activityPanel',
-                    name: 'Remove Activity Panel',
-                    note: 'Removes the activity panel from the user voice chat panel.',
-                    value: false,
-                },
             ],
         },
         {
@@ -638,6 +631,13 @@ const config = {
                     id: 'statusNudgePopup',
                     name: 'Remove Status Change Nudge',
                     note: 'Removes the status change popup if you are not set to available.',
+                    value: false,
+                },
+                {
+                    type: 'switch',
+                    id: 'activityPanel',
+                    name: 'Remove Activity Panel',
+                    note: 'Removes the activity panel from the user voice chat panel.',
                     value: false,
                 },
             ],


### PR DESCRIPTION
Whenever the user is playing a registered game according to [IGDB](https://www.igdb.com/about), the activity panel shows up with a button to stream to a voice channel. This happens regardless of native app settings such as "Share my activity" being toggled off. The only way to mitigate this is to manually hide "Toggle detection" for every registered game in the Registered Games Section under Activity Settings. However, playing a new game will automatically add it as a registered game and toggle it on.

This pull request adds an option to remove the activity panel entirely, which bypasses this problem altogether.

**Before:**
<img width="315" height="168" alt="before" src="https://github.com/user-attachments/assets/90a03913-08e3-4b14-81c6-5f4e1b8ec525" />

**After:**
<img width="315" height="168" alt="after" src="https://github.com/user-attachments/assets/ba88c8a0-3269-4d0d-a019-495c862835d4" />
